### PR TITLE
pandas updates and updated error catching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ docs/_build/
 #Mac ignored files
 ####################
 .DS_Store
+
+.history/

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ docs/_build/
 
 
 .history/
+.vscode/
+.spyder/

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ docs/_build/
 #Mac ignored files
 ####################
 .DS_Store
+
+
+.history/

--- a/obsio/providers/acis.py
+++ b/obsio/providers/acis.py
@@ -295,6 +295,6 @@ class AcisObsIO(ObsIO):
         obs_all = obs_all.rename(columns={'uid': 'station_id'})
 
         obs_all = obs_all.set_index(['station_id', 'elem', 'time'])
-        obs_all = obs_all.sortlevel(0, sort_remaining=True)
+        obs_all = obs_all.sort_index(0, sort_remaining=True)
 
         return obs_all

--- a/obsio/providers/ghcnd.py
+++ b/obsio/providers/ghcnd.py
@@ -585,7 +585,7 @@ class GhcndBulkObsIO(ObsIO):
             pd.set_option('mode.chained_assignment', opt_val)
 
         df_obs = df_obs.set_index(['station_id', 'elem', 'time'])
-        df_obs = df_obs.sortlevel(0, sort_remaining=True)
+        df_obs = df_obs.sort_index(0, sort_remaining=True)
 
         return df_obs
 
@@ -679,6 +679,6 @@ class GhcndObsIO(ObsIO):
             pd.set_option('mode.chained_assignment', opt_val)
 
         df_obs = df_obs.set_index(['station_id', 'elem', 'time'])
-        df_obs = df_obs.sortlevel(0, sort_remaining=True)
+        df_obs = df_obs.sort_index(0, sort_remaining=True)
 
         return df_obs

--- a/obsio/providers/hdf.py
+++ b/obsio/providers/hdf.py
@@ -55,7 +55,7 @@ class HdfObsIO(ObsIO):
         obs.name = 'obs_value'
         obs.index.rename('elem', level=2, inplace=True)
         obs = obs.reorder_levels(['station_id', 'elem',
-                                  'time']).sortlevel(0, sort_remaining=True)
+                                  'time']).sort_index(0, sort_remaining=True)
         obs = pd.DataFrame(obs)
         
         return obs

--- a/obsio/providers/isd.py
+++ b/obsio/providers/isd.py
@@ -386,6 +386,6 @@ class IsdLiteObsIO(ObsIO):
             pd.set_option('mode.chained_assignment', opt_val)
             
         obs_all = obs_all.set_index(['station_id', 'elem', 'time'])
-        obs_all = obs_all.sortlevel(0, sort_remaining=True)
+        obs_all = obs_all.sort_index(0, sort_remaining=True)
 
         return obs_all

--- a/obsio/providers/madis.py
+++ b/obsio/providers/madis.py
@@ -1744,7 +1744,7 @@ class MadisObsIO(ObsIO):
 
         all_obs = pd.concat(all_obs, ignore_index=True)
         all_obs = all_obs.set_index(['station_id', 'elem', 'time'])
-        all_obs = all_obs.sortlevel(0, sort_remaining=True)
+        all_obs = all_obs.sort_index(0, sort_remaining=True)
 
         return all_obs
 

--- a/obsio/providers/netcdf.py
+++ b/obsio/providers/netcdf.py
@@ -61,7 +61,7 @@ class NcObsIO(ObsIO):
         obs = pd.concat(obs)
         
         obs = obs.reorder_levels(['station_id', 'elem',
-                                  'time']).sortlevel(0, sort_remaining=True)
+                                  'time']).sort_index(0, sort_remaining=True)
         
         return obs
     

--- a/obsio/providers/nrcs.py
+++ b/obsio/providers/nrcs.py
@@ -501,7 +501,7 @@ class _NrcsDaily():
 
                 try:
                     obs_stn = pd.DataFrame(a_data.values, columns=['obs_value'])
-                    obs_stn['time'] = pd.date_range(a_data.beginDate, a_data.endDate)
+                    obs_stn['time'] = pd.date_range(a_data.beginDate.apply(repr), a_data.endDate.apply(repr))
                     obs_stn['stationTriplet'] = a_data.stationTriplet
                     obs_stn['obs_value'] = _convert_funcs[a_elem](obs_stn['obs_value'])
                     obs_stn['elem'] = a_elem
@@ -628,7 +628,7 @@ class NrcsObsIO(ObsIO):
         self._nrcs_dly = _NrcsDaily(self._client, self._elems_nrcs_dly)
         self._nrcs_hrly = _NrcsHourly(self._client, self._elems_nrcs_hrly)
         
-        self._elem_funcs = np.unique(np.array([_ELEM_EXTRACT_FUNCS[a_elem] for
+        self._elem_funcs = pd.unique(np.array([_ELEM_EXTRACT_FUNCS[a_elem] for
                                                a_elem in self.elems]))
 
     def _read_stns(self):
@@ -657,14 +657,15 @@ class NrcsObsIO(ObsIO):
                                        stationTriplets=stn_triplets)
 
         stn_tups = [self._stationMetadata_to_tuple(a) for a in stn_metas]
+        
         df_stns = pd.DataFrame(stn_tups, columns=self._stnmeta_attrs)
 
         stns = df_stns.rename(columns={'actonId': 'station_id',
                                        'name': 'station_name'})
         stns['station_id'] = stns.station_id.fillna(stns.stationTriplet)
         stns = stns[~stns.station_id.isnull()]
-        stns['beginDate'] = pd.to_datetime(stns.beginDate)
-        stns['endDate'] = pd.to_datetime(stns.endDate)
+        stns['beginDate'] = pd.to_datetime(stns.beginDate.apply(repr))
+        stns['endDate'] = pd.to_datetime(stns.endDate.apply(repr))
         stns['elevation'] = _ft_to_m(stns.elevation)
         stns['provider'] = 'NRCS'
         stns['sub_provider'] = ''
@@ -740,7 +741,7 @@ class NrcsObsIO(ObsIO):
 
         obs_merge = obs_merge.drop('stationTriplet', axis=1)
         obs_merge = obs_merge.set_index(['station_id', 'elem', 'time'])
-        obs_merge = obs_merge.sortlevel(0, sort_remaining=True)
+        obs_merge = obs_merge.sort_index(0, sort_remaining=True)
         return obs_merge
 
     def _stationMetadata_to_tuple(self, a_meta):

--- a/obsio/providers/uscrn.py
+++ b/obsio/providers/uscrn.py
@@ -102,6 +102,6 @@ class UscrnObsIO(ObsIO):
              
         obs_all = pd.concat(obs_all, ignore_index=True)
         obs_all = obs_all.set_index(['station_id', 'elem', 'time'])
-        obs_all = obs_all.sortlevel(0, sort_remaining=True)
+        obs_all = obs_all.sort_index(0, sort_remaining=True)
 
         return obs_all

--- a/obsio/providers/ushcn.py
+++ b/obsio/providers/ushcn.py
@@ -161,7 +161,7 @@ class UshcnObsIO(ObsIO):
 
         obs_file.close()
 
-        obs = obs.unstack().swaplevel(0, 1).sortlevel(0, sort_remaining=True)
+        obs = obs.unstack().swaplevel(0, 1).sort_index(0, sort_remaining=True)
         obs = obs.reset_index()
         obs['time'] = pd.to_datetime(obs.year.astype(np.str) + obs.level_1,
                                      format='%Y%m')
@@ -207,6 +207,6 @@ class UshcnObsIO(ObsIO):
             pd.set_option('mode.chained_assignment', opt_val)
 
         obs = obs.set_index(['station_id', 'elem', 'time'])
-        obs = obs.sortlevel(0, sort_remaining=True)
+        obs = obs.sort_index(0, sort_remaining=True)
 
         return obs

--- a/obsio/providers/wrcc.py
+++ b/obsio/providers/wrcc.py
@@ -517,6 +517,6 @@ class WrccRawsObsIO(ObsIO):
             
         df_obs = pd.concat(obs, ignore_index=True)
         df_obs = df_obs.set_index(['station_id', 'elem', 'time'])
-        df_obs = df_obs.sortlevel(0, sort_remaining=True)
+        df_obs = df_obs.sort_index(0, sort_remaining=True)
 
         return df_obs

--- a/obsio/util/misc.py
+++ b/obsio/util/misc.py
@@ -324,14 +324,11 @@ def download_if_new_ftp(a_ftp, fpath_ftp, fpath_local):
         mtime_local = datetime.utcfromtimestamp(os.path.getmtime(fpath_local))
         size_local = os.path.getsize(fpath_local)
     
-    except OSError as e:
+    except FileNotFoundError as e:
         
-        if e.args[-1] == 'No such file or directory':
-            mtime_local = None
-            size_local = None
-        else:
-            raise
-    
+        mtime_local = None
+        size_local = None
+
     if (size_remote != size_local) or (mtime_remote > mtime_local):
         
         print("Downloading %s to %s..."%(fpath_ftp, fpath_local))


### PR DESCRIPTION
Hi Jared,
I guess you aren't really working on this anymore but it's a shame because as you know most hydrologists don't have the skills to create this sorely needed tool!
a couple fixes for nrcs downloader that are mostly updates to pandas
1. pd.sortlevel() is now pd.sort_index()
2. pd datetime won't accept the unicode coming from suds so I used repr() to get the string representation where needed. maybe there is a better way?

at least the suds error is resolved in v1.4.x so closes #3 

this resolves the issues I was having downloading station metadata. 
Running the example in the README isn't working due to a missing ghcn files and I couldn't download the data from nrcs with read_obs() (it was returning an empty df, no error)

